### PR TITLE
 selftests/bpf: fix netdevsim trap_flow_action_cookie read

### DIFF
--- a/tools/testing/selftests/bpf/test_offload.py
+++ b/tools/testing/selftests/bpf/test_offload.py
@@ -318,6 +318,9 @@ class DebugfsDir:
                 continue
 
             if os.path.isfile(p):
+                # We need to init trap_flow_action_cookie before read it
+                if f == "trap_flow_action_cookie":
+                    cmd('echo deadbeef > %s/%s' % (path, f))
                 _, out = cmd('cat %s/%s' % (path, f))
                 dfs[f] = out.strip()
             elif os.path.isdir(p):


### PR DESCRIPTION
Pull request for series with
subject:  selftests/bpf: fix netdevsim trap_flow_action_cookie read
version: 1
url:https://patchwork.ozlabs.org/api/1.1/series/192530/
