### PR TITLE
 bpf: add missing return to resolve_btfids

### DIFF
--- a/tools/bpf/resolve_btfids/main.c
+++ b/tools/bpf/resolve_btfids/main.c
@@ -566,6 +566,7 @@ static int sets_patch(struct object *obj)
 
 		next = rb_next(next);
 	}
+	return 0;
 }
 
 static int symbols_patch(struct object *obj)


### PR DESCRIPTION
Pull request for series with
subject:  bpf: add missing return to resolve_btfids
version: 1
url:https://patchwork.ozlabs.org/api/1.1/series/194501/
