### PR TITLE
bpf: selftests: global_funcs: check err_str before strstr

### DIFF
--- a/tools/testing/selftests/bpf/prog_tests/test_global_funcs.c
+++ b/tools/testing/selftests/bpf/prog_tests/test_global_funcs.c
@@ -19,7 +19,7 @@ static int libbpf_debug_print(enum libbpf_print_level level,
 	log_buf = va_arg(args, char *);
 	if (!log_buf)
 		goto out;
-	if (strstr(log_buf, err_str) == 0)
+	if ((err_str != NULL) && (strstr(log_buf, err_str) == 0))
 		found = true;
 out:
 	printf(format, log_buf);


### PR DESCRIPTION
Pull request for series with
subject: bpf: selftests: global_funcs: check err_str before strstr
version: 1
url: https://patchwork.ozlabs.org/project/netdev/list/?series=196349
