### PR TITLE
selftests/bpf: Remove test_align from TEST_GEN_PROGS

### DIFF
--- a/tools/testing/selftests/bpf/Makefile
+++ b/tools/testing/selftests/bpf/Makefile
@@ -32,7 +32,7 @@ LDLIBS += -lcap -lelf -lz -lrt -lpthread
 
 # Order correspond to 'make run_tests' order
 TEST_GEN_PROGS = test_verifier test_tag test_maps test_lru_map test_lpm_map test_progs \
-	test_align test_verifier_log test_dev_cgroup test_tcpbpf_user \
+	test_verifier_log test_dev_cgroup test_tcpbpf_user \
 	test_sock test_btf test_sockmap get_cgroup_id_user test_socket_cookie \
 	test_cgroup_storage \
 	test_netcnt test_tcpnotify_user test_sock_fields test_sysctl \


### PR DESCRIPTION
Pull request for series with
subject: selftests/bpf: Remove test_align from TEST_GEN_PROGS
version: 1
url: https://patchwork.ozlabs.org/project/netdev/list/?series=196420
