### PR TITLE
 libbpf: fix map index used in error message

### DIFF
--- a/tools/lib/bpf/libbpf.c
+++ b/tools/lib/bpf/libbpf.c
@@ -2264,7 +2264,7 @@ static int bpf_object__init_user_btf_maps(struct bpf_object *obj, bool strict,
 		data = elf_getdata(scn, NULL);
 	if (!scn || !data) {
 		pr_warn("failed to get Elf_Data from map section %d (%s)\n",
-			obj->efile.maps_shndx, MAPS_ELF_SEC);
+			obj->efile.btf_maps_shndx, MAPS_ELF_SEC);
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
Pull request for series with
subject:  libbpf: fix map index used in error message
version: 1
url: https://patchwork.ozlabs.org/project/netdev/list/?series=196433
